### PR TITLE
[FJD-86] Enable Metatag AI module

### DIFF
--- a/booster.info.yml
+++ b/booster.info.yml
@@ -61,6 +61,7 @@ install:
   - media_directories_ui
   - media_library
   - metatag
+  - metatag_ai
   - openai
   - openai_ckeditor
   - node

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "drupal/media_directories": "^2.1@beta",
         "drupal/memcache": "^2.5",
         "drupal/metatag": "^2.0",
+        "drupal/metatag_ai": "^1.0",
         "drupal/openai": "^1.0@beta",
         "drupal/password_policy": "^4.0",
         "drupal/pathauto": "^1.12",

--- a/config/install/metatag_ai.content_settings.yml
+++ b/config/install/metatag_ai.content_settings.yml
@@ -1,0 +1,4 @@
+metatag_ai:
+  metadata_content_types:
+    page: page
+  metadata_field_id: field_meta_tags

--- a/config/install/metatag_ai.settings.yml
+++ b/config/install/metatag_ai.settings.yml
@@ -1,0 +1,11 @@
+metatag_ai:
+  service: openai
+  metatagai_endpoint: 'https://api.openai.com/v1/chat/completions'
+  metatagai_model: gpt-3.5-turbo
+  metatagai_max_token: '256'
+  metatagai_temperature: '1'
+  metatagai_token: ''
+  metatagai_max_context_length: '4096'
+  awsbedrock_api_key: ''
+  awsbedrock_api_secret: ''
+  awsbedrock_region: ''


### PR DESCRIPTION
Jira issue: [FJD-86](https://fivejars.atlassian.net/browse/FJD-86)

Steps to review:
- [ ] login as admin
- [ ] got to basic page creation form
- [ ] open the metatag section(right) and overview values
- [ ] fill some title and body and clink on to "Generate metatag" button
- [ ] ensure that generated data were filled at the metatag section
